### PR TITLE
fix: CI web build for examples sub-module

### DIFF
--- a/tools/build_web_native_emcc.sh
+++ b/tools/build_web_native_emcc.sh
@@ -57,6 +57,11 @@ while [[ "$parent" != "." ]]; do
   parent="$(dirname "$parent")"
 done
 
+# Ensure sub-module dependencies are installed (.mooncakes is gitignored)
+if [[ "$MODULE_DIR" != "." ]]; then
+  (cd "$MODULE_DIR" && moon update)
+fi
+
 echo "[1/3] Building MoonBit package with native backend: $PKG_PATH"
 (cd "$MODULE_DIR" && moon build --target native "$BUILD_PKG_PATH")
 


### PR DESCRIPTION
## Summary

- Fix `tools/build_web_native_emcc.sh` broken by `5573c94` which made `examples/` its own MoonBit module
- Detect sub-modules by walking up the package path for `moon.mod.json`, then run `moon build` from within the sub-module directory with the relative package path
- Run `moon update` in the sub-module to resolve dependencies (`.mooncakes/` is gitignored)
- Restrict the publish workflow to only run on pushes to `main`, avoiding 153-game builds on every branch push

## Test plan

- [x] `tools/build_web_native_emcc.sh examples/raylib_demo` succeeds locally
- [x] CI passed on previous push (run 22436886193)

🤖 Generated with [Claude Code](https://claude.com/claude-code)