### PR TITLE
ci: only run web games publish on pushes to main

### DIFF
--- a/.github/workflows/publish-web-games-pages.yml
+++ b/.github/workflows/publish-web-games-pages.yml
@@ -2,6 +2,7 @@ name: Publish Web Games To Pages Repo
 
 on:
   push:
+    branches: [main]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

- Restrict the publish workflow to only trigger on pushes to `main` branch, not on every branch push
- Avoids building all 153 web game bundles on PR branch pushes
- Manual `workflow_dispatch` still works

## Test plan

- [ ] Verify workflow does not trigger on branch pushes
- [ ] Verify workflow triggers on merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)