### PR TITLE
refactor: extract Input struct to decouple game logic from raylib

### DIFF
--- a/examples/raylib_super_mario_1985_lite/ARCHITECTURE.md
+++ b/examples/raylib_super_mario_1985_lite/ARCHITECTURE.md
@@ -1,0 +1,89 @@
+# Super Mario 1985 Lite — Architecture
+
+## Package layout
+
+```
+raylib_super_mario_1985_lite/
+├── main.mbt            # Entry point: window, main loop, read_input()
+├── moon.pkg            # Root package (is-main), imports game/render/types/raylib
+├── types/
+│   ├── moon.pkg        # Imports core/math, tonyfettes/raylib
+│   ├── types.mbt       # Input, Player, Enemy, Coin, Particle, Game structs
+│   ├── constants.mbt   # All gameplay tuning constants
+│   └── utils.mbt       # Tile helpers, math utils, collision checks
+├── game/
+│   ├── moon.pkg        # Imports types, particles, raylib, core/math
+│   ├── game_update.mbt # update_game (pub), update_playing, tick_level_timer, update_camera
+│   ├── player_system.mbt  # update_player, physics resolution, flag sequence, hurt logic
+│   ├── enemy_system.mbt   # update_enemies, stomp detection, enemy AI
+│   ├── coin_system.mbt    # update_coins, collection detection
+│   └── level.mbt       # Level geometry builder, entity spawner, reset logic
+├── particles/
+│   ├── moon.pkg        # Imports types, raylib, core/math
+│   └── particles.mbt   # Particle allocation, update, spawn helpers (coin/stomp/hurt/block bursts)
+└── render/
+    ├── moon.pkg        # Imports types, raylib, core/math
+    └── render.mbt      # draw_world, draw_ui (HUD, title, game-over screens)
+```
+
+## Data flow
+
+```
+main loop
+  │
+  ├─ read_input()          → Input struct (raylib key state snapshot)
+  │
+  ├─ update_game(game, input, dt)
+  │     │
+  │     ├─ state_title:    particles update; input.accept → reset_full_run
+  │     ├─ state_playing:  update_playing(game, input, dt)
+  │     │     ├─ tick_level_timer
+  │     │     ├─ update_player(game, input, dt)   ← uses input for movement/jump
+  │     │     ├─ update_enemies
+  │     │     ├─ update_coins
+  │     │     ├─ update_particles
+  │     │     └─ update_camera
+  │     └─ state_win/game_over: particles update; input.restart → reset_full_run
+  │
+  ├─ begin_drawing / clear
+  ├─ draw_world(game)      → tiles, entities, particles
+  ├─ draw_ui(game)         → HUD, overlay screens
+  └─ end_drawing
+```
+
+## Input decoupling
+
+Game logic does **not** call raylib input functions directly.
+All input reading happens in `read_input()` (in `main.mbt`), which produces an
+`Input` struct with 6 boolean fields:
+
+| Field          | Meaning                        | Keys                        |
+|----------------|--------------------------------|-----------------------------|
+| `move_left`    | Horizontal movement            | A, Left                     |
+| `move_right`   | Horizontal movement            | D, Right                    |
+| `jump_pressed` | Jump initiation (edge trigger) | W, Up, Space                |
+| `jump_held`    | Variable-height jump (held)    | W, Up, Space                |
+| `accept`       | Title screen start             | Enter, Space                |
+| `restart`      | Win/game-over restart          | Enter, Space, R             |
+
+This allows `update_game` to be called from `moon test` with synthetic `Input`
+values, enabling simulation tests without a raylib window.
+
+## Key design decisions
+
+- **Structs are mutable** (`mut` fields) — game state is updated in-place each frame.
+- **Fixed-size arrays** for enemies, coins, particles — pool allocation with `active` flags.
+- **Tile map** is a flat `Array[Int]` indexed by `ty * world_tiles_w + tx`.
+- **Physics** uses separate X/Y resolution passes (sweep against tile grid).
+- **Coyote time + jump buffering** for responsive platformer feel.
+- **Invulnerability timer** after taking damage, with position-reset on pit fall.
+- **Flag sequence** is a 3-phase state machine (slide down → walk to castle → win).
+
+## Testing
+
+Tests live alongside their packages and run with `moon test --target native`:
+
+- `types/utils_test.mbt` — Pure unit tests for tile helpers, math, collision.
+- `game/game_test.mbt` — Simulation tests: gravity, landing, jump, coin pickup,
+  enemy stomp/hurt, invulnerability regression, flag trigger, timer expiry.
+  These construct `Game` + `Input` manually and call `update_game` directly.

--- a/examples/raylib_super_mario_1985_lite/game/game_test.mbt
+++ b/examples/raylib_super_mario_1985_lite/game/game_test.mbt
@@ -1,0 +1,201 @@
+///|
+fn setup_game() -> @types.Game {
+  let game = @types.Game::new()
+  @types.fill_rect_tile(
+    game,
+    0,
+    @types.ground_row,
+    @types.world_tiles_w,
+    @types.world_tiles_h - @types.ground_row,
+    @types.tile_ground,
+  )
+  let ground_y = @types.tile_top(@types.ground_row) -
+    @types.player_half_h() -
+    0.01
+  game.player.x = @types.player_start_x
+  game.player.y = ground_y
+  game.player.on_ground = true
+  game.player.lives = 3
+  game.player.coins = 0
+  game.player.score = 0
+  game.state = @types.state_playing
+  game.start_y = ground_y
+  game.flag_x = @types.tile_center_x(214)
+  game.flag_top_y = @types.tile_top(8)
+  game.flag_bottom_y = @types.tile_top(@types.ground_row) -
+    @types.player_half_h() -
+    0.01
+  game.castle_x = @types.tile_left(226) + @types.tile_size_f
+  game
+}
+
+///|
+let no_input : @types.Input = {
+  move_left: false,
+  move_right: false,
+  jump_pressed: false,
+  jump_held: false,
+  accept: false,
+  restart: false,
+}
+
+///|
+let dt : Float = 1.0 / 60.0
+
+///|
+test "gravity: player in air falls" {
+  let game = setup_game()
+  game.player.y = @types.tile_top(@types.ground_row) - 200.0
+  game.player.on_ground = false
+  let y_before = game.player.y
+  for i = 0; i < 10; i = i + 1 {
+    update_game(game, no_input, dt)
+  }
+  assert_true(game.player.y > y_before)
+}
+
+///|
+test "ground collision: player lands on tile" {
+  let game = setup_game()
+  game.player.y = @types.tile_top(@types.ground_row) -
+    @types.player_half_h() -
+    5.0
+  game.player.vy = 200.0
+  game.player.on_ground = false
+  for i = 0; i < 5; i = i + 1 {
+    update_game(game, no_input, dt)
+  }
+  assert_true(game.player.on_ground)
+}
+
+///|
+test "jump: player vy goes negative on ground with jump_pressed" {
+  let game = setup_game()
+  game.player.on_ground = true
+  let jump_input : @types.Input = {
+    move_left: false,
+    move_right: false,
+    jump_pressed: true,
+    jump_held: true,
+    accept: false,
+    restart: false,
+  }
+  update_game(game, jump_input, dt)
+  assert_true(game.player.vy < 0.0)
+}
+
+///|
+test "coin collection: player overlaps coin increments coins" {
+  let game = setup_game()
+  let player = game.player
+  game.coins[0] = @types.Coin::spawn(player.x, player.y, 0.0)
+  let coins_before = player.coins
+  update_game(game, no_input, dt)
+  assert_true(player.coins > coins_before)
+  assert_false(game.coins[0].active)
+}
+
+///|
+test "enemy stomp: player above enemy with high vy squashes enemy" {
+  let game = setup_game()
+  let player = game.player
+  let enemy_x = player.x + 5.0
+  let enemy_y = @types.tile_top(@types.ground_row) -
+    @types.enemy_half_h() -
+    0.01
+  game.enemies[0] = @types.Enemy::spawn(enemy_x, enemy_y, -1)
+  player.x = enemy_x
+  player.y = enemy_y - @types.player_half_h() - @types.enemy_half_h() + 5.0
+  player.vy = 500.0
+  player.on_ground = false
+  update_game(game, no_input, dt)
+  assert_true(game.enemies[0].squashed)
+}
+
+///|
+test "enemy hurt: side collision decrements lives" {
+  let game = setup_game()
+  let player = game.player
+  let lives_before = player.lives
+  let enemy_x = player.x + @types.player_half_w() + @types.enemy_half_w() -
+    5.0
+  let enemy_y = player.y
+  game.enemies[0] = @types.Enemy::spawn(enemy_x, enemy_y, -1)
+  player.vy = 0.0
+  update_game(game, no_input, dt)
+  assert_true(player.lives < lives_before)
+}
+
+///|
+test "invulnerable player falls off world: position reset, no extra life lost" {
+  let game = setup_game()
+  let player = game.player
+  player.invuln_t = 1.0
+  player.y = @types.world_height_px + 100.0
+  player.on_ground = false
+  let lives_before = player.lives
+  update_game(game, no_input, dt)
+  assert_eq(player.lives, lives_before)
+  assert_true(player.y < @types.world_height_px)
+}
+
+///|
+test "two adjacent enemies: stomp one, no hurt from second" {
+  let game = setup_game()
+  let player = game.player
+  let enemy_y = @types.tile_top(@types.ground_row) -
+    @types.enemy_half_h() -
+    0.01
+  game.enemies[0] = @types.Enemy::spawn(player.x, enemy_y, -1)
+  game.enemies[1] = @types.Enemy::spawn(
+    player.x + @types.enemy_half_w() * 2.0 + 2.0,
+    enemy_y,
+    -1,
+  )
+  player.x = game.enemies[0].x
+  player.y = enemy_y - @types.player_half_h() - @types.enemy_half_h() + 5.0
+  player.vy = 500.0
+  player.on_ground = false
+  let lives_before = player.lives
+  update_game(game, no_input, dt)
+  assert_true(game.enemies[0].squashed)
+  assert_eq(player.lives, lives_before)
+}
+
+///|
+test "flag trigger: player reaches flag x sets reached_flag" {
+  let game = setup_game()
+  let player = game.player
+  player.x = game.flag_x - @types.player_half_w()
+  player.y = game.flag_bottom_y
+  player.on_ground = true
+  let right_input : @types.Input = {
+    move_left: false,
+    move_right: true,
+    jump_pressed: false,
+    jump_held: false,
+    accept: false,
+    restart: false,
+  }
+  for i = 0; i < 30; i = i + 1 {
+    update_game(game, right_input, dt)
+    if player.reached_flag {
+      break
+    }
+  }
+  assert_true(player.reached_flag)
+}
+
+///|
+test "timer expiry: time runs out triggers game over" {
+  let game = setup_game()
+  game.time_left = 1
+  game.time_accum = 0.0
+  for i = 0; i < 120; i = i + 1 {
+    if game.state != @types.state_playing {
+      break
+    }
+    update_game(game, no_input, dt)
+  }
+  assert_eq(game.state, @types.state_game_over)
+}

--- a/examples/raylib_super_mario_1985_lite/game/game_update.mbt
+++ b/examples/raylib_super_mario_1985_lite/game/game_update.mbt
@@ -1,15 +1,4 @@
 ///|
-fn is_accept_pressed() -> Bool {
-  @raylib.is_key_pressed(@raylib.KeyEnter) ||
-  @raylib.is_key_pressed(@raylib.KeySpace)
-}
-
-///|
-fn is_restart_pressed() -> Bool {
-  is_accept_pressed() || @raylib.is_key_pressed(@raylib.KeyR)
-}
-
-///|
 fn update_camera(game : @types.Game, dt : Float) -> Unit {
   let width_f = Float::from_int(@types.screen_width)
   let mut target_x = if game.player.reached_flag {
@@ -46,13 +35,13 @@ fn tick_level_timer(game : @types.Game, dt : Float) -> Unit {
 }
 
 ///|
-fn update_playing(game : @types.Game, dt : Float) -> Unit {
+fn update_playing(game : @types.Game, input : @types.Input, dt : Float) -> Unit {
   tick_level_timer(game, dt)
   if game.state != @types.state_playing {
     return
   }
 
-  update_player(game, dt)
+  update_player(game, input, dt)
   update_enemies(game, dt)
   update_coins(game, dt)
   @particles.update_particles(game, dt)
@@ -76,24 +65,24 @@ pub fn init_game(game : @types.Game) -> Unit {
 }
 
 ///|
-pub fn update_game(game : @types.Game, dt : Float) -> Unit {
+pub fn update_game(game : @types.Game, input : @types.Input, dt : Float) -> Unit {
   game.elapsed += dt
 
   if game.state == @types.state_title {
     @particles.update_particles(game, dt)
-    if is_accept_pressed() {
+    if input.accept {
       reset_full_run(game)
     }
     return
   }
 
   if game.state == @types.state_playing {
-    update_playing(game, dt)
+    update_playing(game, input, dt)
     return
   }
 
   @particles.update_particles(game, dt)
-  if is_restart_pressed() {
+  if input.restart {
     reset_full_run(game)
   }
 }

--- a/examples/raylib_super_mario_1985_lite/game/player_system.mbt
+++ b/examples/raylib_super_mario_1985_lite/game/player_system.mbt
@@ -1,28 +1,4 @@
 ///|
-fn is_move_left_down() -> Bool {
-  @raylib.is_key_down(@raylib.KeyA) || @raylib.is_key_down(@raylib.KeyLeft)
-}
-
-///|
-fn is_move_right_down() -> Bool {
-  @raylib.is_key_down(@raylib.KeyD) || @raylib.is_key_down(@raylib.KeyRight)
-}
-
-///|
-fn is_jump_pressed() -> Bool {
-  @raylib.is_key_pressed(@raylib.KeyW) ||
-  @raylib.is_key_pressed(@raylib.KeyUp) ||
-  @raylib.is_key_pressed(@raylib.KeySpace)
-}
-
-///|
-fn is_jump_down() -> Bool {
-  @raylib.is_key_down(@raylib.KeyW) ||
-  @raylib.is_key_down(@raylib.KeyUp) ||
-  @raylib.is_key_down(@raylib.KeySpace)
-}
-
-///|
 fn collect_coin(game : @types.Game, x : Float, y : Float) -> Unit {
   let player = game.player
   player.coins += 1
@@ -227,7 +203,7 @@ fn on_player_hurt(game : @types.Game) -> Unit {
 }
 
 ///|
-fn update_player(game : @types.Game, dt : Float) -> Unit {
+fn update_player(game : @types.Game, input : @types.Input, dt : Float) -> Unit {
   let player = game.player
 
   if player.invuln_t > 0.0 {
@@ -242,7 +218,7 @@ fn update_player(game : @types.Game, dt : Float) -> Unit {
     return
   }
 
-  if is_jump_pressed() {
+  if input.jump_pressed {
     player.jump_buf_t = @types.jump_buffer_time
   } else if player.jump_buf_t > 0.0 {
     player.jump_buf_t = player.jump_buf_t - dt
@@ -251,8 +227,8 @@ fn update_player(game : @types.Game, dt : Float) -> Unit {
     }
   }
 
-  let left = is_move_left_down()
-  let right = is_move_right_down()
+  let left = input.move_left
+  let right = input.move_right
   let move_axis = if left && not(right) {
     -1
   } else if right && not(left) {
@@ -286,7 +262,7 @@ fn update_player(game : @types.Game, dt : Float) -> Unit {
     player.jump_buf_t = 0.0
   }
 
-  if not(is_jump_down()) && player.vy < 0.0 {
+  if not(input.jump_held) && player.vy < 0.0 {
     player.vy += @types.gravity * dt * (1.0 - @types.jump_cut_multiplier)
   }
 

--- a/examples/raylib_super_mario_1985_lite/main.mbt
+++ b/examples/raylib_super_mario_1985_lite/main.mbt
@@ -1,4 +1,23 @@
 ///|
+fn read_input() -> @types.Input {
+  {
+    move_left: @raylib.is_key_down(@raylib.KeyA) || @raylib.is_key_down(@raylib.KeyLeft),
+    move_right: @raylib.is_key_down(@raylib.KeyD) || @raylib.is_key_down(@raylib.KeyRight),
+    jump_pressed: @raylib.is_key_pressed(@raylib.KeyW) ||
+      @raylib.is_key_pressed(@raylib.KeyUp) ||
+      @raylib.is_key_pressed(@raylib.KeySpace),
+    jump_held: @raylib.is_key_down(@raylib.KeyW) ||
+      @raylib.is_key_down(@raylib.KeyUp) ||
+      @raylib.is_key_down(@raylib.KeySpace),
+    accept: @raylib.is_key_pressed(@raylib.KeyEnter) ||
+      @raylib.is_key_pressed(@raylib.KeySpace),
+    restart: @raylib.is_key_pressed(@raylib.KeyEnter) ||
+      @raylib.is_key_pressed(@raylib.KeySpace) ||
+      @raylib.is_key_pressed(@raylib.KeyR),
+  }
+}
+
+///|
 fn main {
   @raylib.set_config_flags(@raylib.FlagMsaa4xHint)
   @raylib.init_window(
@@ -15,7 +34,8 @@ fn main {
       dt = 0.05
     }
 
-    @game.update_game(game, dt)
+    let input = read_input()
+    @game.update_game(game, input, dt)
 
     @raylib.begin_drawing()
     @raylib.clear_background(@raylib.black)

--- a/examples/raylib_super_mario_1985_lite/types/types.mbt
+++ b/examples/raylib_super_mario_1985_lite/types/types.mbt
@@ -1,4 +1,26 @@
 ///|
+pub(all) struct Input {
+  move_left : Bool
+  move_right : Bool
+  jump_pressed : Bool
+  jump_held : Bool
+  accept : Bool
+  restart : Bool
+}
+
+///|
+pub fn Input::none() -> Input {
+  {
+    move_left: false,
+    move_right: false,
+    jump_pressed: false,
+    jump_held: false,
+    accept: false,
+    restart: false,
+  }
+}
+
+///|
 pub(all) struct Player {
   mut x : Float
   mut y : Float

--- a/examples/raylib_super_mario_1985_lite/types/utils_test.mbt
+++ b/examples/raylib_super_mario_1985_lite/types/utils_test.mbt
@@ -1,0 +1,135 @@
+///|
+test "tile_is_solid: ground is solid" {
+  assert_true(tile_is_solid(tile_ground))
+}
+
+///|
+test "tile_is_solid: brick is solid" {
+  assert_true(tile_is_solid(tile_brick))
+}
+
+///|
+test "tile_is_solid: question is solid" {
+  assert_true(tile_is_solid(tile_question))
+}
+
+///|
+test "tile_is_solid: used is solid" {
+  assert_true(tile_is_solid(tile_used))
+}
+
+///|
+test "tile_is_solid: pipe is solid" {
+  assert_true(tile_is_solid(tile_pipe))
+}
+
+///|
+test "tile_is_solid: castle is solid" {
+  assert_true(tile_is_solid(tile_castle))
+}
+
+///|
+test "tile_is_solid: empty is not solid" {
+  assert_false(tile_is_solid(tile_empty))
+}
+
+///|
+test "tile_is_solid: flag_pole is not solid" {
+  assert_false(tile_is_solid(tile_flag_pole))
+}
+
+///|
+test "rects_overlap: overlapping rects" {
+  assert_true(rects_overlap(0.0, 0.0, 10.0, 10.0, 5.0, 5.0, 15.0, 15.0))
+}
+
+///|
+test "rects_overlap: non-overlapping rects" {
+  assert_false(rects_overlap(0.0, 0.0, 10.0, 10.0, 20.0, 20.0, 30.0, 30.0))
+}
+
+///|
+test "rects_overlap: touching edges do not overlap" {
+  assert_false(rects_overlap(0.0, 0.0, 10.0, 10.0, 10.0, 0.0, 20.0, 10.0))
+}
+
+///|
+test "rects_overlap: contained rect" {
+  assert_true(rects_overlap(0.0, 0.0, 20.0, 20.0, 5.0, 5.0, 10.0, 10.0))
+}
+
+///|
+test "clampf: within range" {
+  assert_eq(clampf(5.0, 0.0, 10.0), 5.0)
+}
+
+///|
+test "clampf: below min" {
+  assert_eq(clampf(-3.0, 0.0, 10.0), 0.0)
+}
+
+///|
+test "clampf: above max" {
+  assert_eq(clampf(15.0, 0.0, 10.0), 10.0)
+}
+
+///|
+test "clampf: at boundaries" {
+  assert_eq(clampf(0.0, 0.0, 10.0), 0.0)
+  assert_eq(clampf(10.0, 0.0, 10.0), 10.0)
+}
+
+///|
+test "clampi: within range" {
+  assert_eq(clampi(5, 0, 10), 5)
+}
+
+///|
+test "clampi: below min" {
+  assert_eq(clampi(-3, 0, 10), 0)
+}
+
+///|
+test "clampi: above max" {
+  assert_eq(clampi(15, 0, 10), 10)
+}
+
+///|
+test "world_to_tile_x: zero" {
+  assert_eq(world_to_tile_x(0.0), 0)
+}
+
+///|
+test "world_to_tile_x: negative clamps to 0" {
+  assert_eq(world_to_tile_x(-10.0), 0)
+}
+
+///|
+test "world_to_tile_x: mid-tile" {
+  assert_eq(world_to_tile_x(48.0), 1)
+}
+
+///|
+test "world_to_tile_x: tile boundary" {
+  assert_eq(world_to_tile_x(64.0), 2)
+}
+
+///|
+test "world_to_tile_x: large value clamps" {
+  assert_eq(world_to_tile_x(100000.0), world_tiles_w - 1)
+}
+
+///|
+test "world_to_tile_y: zero" {
+  assert_eq(world_to_tile_y(0.0), 0)
+}
+
+///|
+test "world_to_tile_y: negative clamps to 0" {
+  assert_eq(world_to_tile_y(-5.0), 0)
+}
+
+///|
+test "world_to_tile_y: large value clamps" {
+  assert_eq(world_to_tile_y(100000.0), world_tiles_h - 1)
+}


### PR DESCRIPTION
Move all raylib input reading into a `read_input()` function in main.mbt that produces an `Input` struct. Thread it through update_game → update_playing → update_player, replacing 6 private input-reading helpers.

This allows game logic to be tested without a raylib window. Add 27 unit tests (types/utils_test.mbt) and 10 simulation tests (game/game_test.mbt) covering physics, collision, scoring, and regression cases. Add ARCHITECTURE.md documenting the package layout and data flow.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbit-community/tonyfettes-raylib/pull/11" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
