### PR TITLE
docs: document that `moon build` is not supported

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,10 @@ MoonBit bindings for raylib 5.5 (`tonyfettes/raylib`). Native-only target (no WA
 
 ## Build Commands
 
+> **Note:** `moon build` (without arguments) will fail with a linker error — this
+> module is a library, not an executable. Always build a specific example package
+> or use `moon check --target native` to type-check.
+
 ```bash
 # Build an example (native only) — examples/ is a separate module
 moon -C examples build --target native raylib_demo/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing
+
+## Prerequisites
+
+- [MoonBit toolchain](https://www.moonbitlang.com/download/) installed
+- Native target support (macOS, Linux, or Windows)
+
+## Building
+
+This module is a **library**, not an executable. Running `moon build` without
+arguments will fail with a linker error (missing `_main`). Use one of the
+following commands instead:
+
+```bash
+# Type-check without building
+moon check --target native
+
+# Build a specific example
+moon -C examples build --target native raylib_demo/
+
+# Run a specific example
+moon -C examples run --target native raylib_tank_1990/
+
+# Run tests
+moon test --target native
+```
+
+The `examples/` directory is a separate module, so `-C examples` is required to
+set the working directory.
+
+## Conventions
+
+- Use conventional commits (e.g., `feat:`, `fix:`, `refactor:`)
+- See [CLAUDE.md](CLAUDE.md) for architecture details, FFI rules, and coding patterns


### PR DESCRIPTION
## Summary
- Add a note to `CLAUDE.md` warning that `moon build` (without arguments) fails because this module is a library, not an executable
- Create `CONTRIBUTING.md` with correct build commands (`moon check`, `moon -C examples build/run`, `moon test`)

Closes #9

## Test plan
- [ ] `moon check --target native` passes
- [ ] `moon -C examples build --target native raylib_demo/` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)