### PR TITLE
fix: guard GetClipboardImage with PLATFORM_ANDROID check

### DIFF
--- a/internal/raylib/stub_textures.c
+++ b/internal/raylib/stub_textures.c
@@ -570,7 +570,11 @@ moonbit_raylib_draw_render_texture_ex(
 ImageWrapper *
 moonbit_raylib_get_clipboard_image(void) {
   ImageWrapper *w = (ImageWrapper *)moonbit_make_external_object(image_destructor, sizeof(ImageWrapper));
+#ifdef PLATFORM_ANDROID
+  w->image = (Image){0};   // clipboard image not supported on Android
+#else
   w->image = GetClipboardImage();
+#endif
   w->freed = 0;
   w->frame_count = 1;
   return w;


### PR DESCRIPTION
## Summary

- Wraps `GetClipboardImage()` in `stub_textures.c` with a `#ifdef PLATFORM_ANDROID` guard
- On Android, returns an empty `Image{0}` since clipboard image access is not supported on that platform
- On all other platforms, behavior is unchanged

## Details

`GetClipboardImage()` is a desktop-only raylib function and fails on Android. This change prevents a call to an unsupported API when building for Android targets.

This fix was originally authored as part of PR #16 (`feat: add Android minesweeper example with touch support`). That PR was closed without merging, but this standalone fix is independently useful for any future Android support.

## Test plan

- [x] Built `raylib_demo` targeting native — no new warnings or errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)