### PR TITLE
fix: use module-relative paths in example change_directory calls

### DIFF
--- a/examples/raylib_audio_module_playing/main.mbt
+++ b/examples/raylib_audio_module_playing/main.mbt
@@ -7,7 +7,7 @@ fn main {
 
   @raylib.set_config_flags(@raylib.FlagMsaa4xHint) // NOTE: Try to enable MSAA 4X
 
-  let _ = @raylib.change_directory("examples/raylib_audio_module_playing")
+  let _ = @raylib.change_directory("raylib_audio_module_playing")
 
   @raylib.init_window(
     screen_width, screen_height, "raylib [audio] example - module playing (streaming)",

--- a/examples/raylib_audio_music_stream/main.mbt
+++ b/examples/raylib_audio_music_stream/main.mbt
@@ -4,7 +4,7 @@ fn main {
   let screen_width = 800
   let screen_height = 450
 
-  let _ = @raylib.change_directory("examples/raylib_audio_music_stream")
+  let _ = @raylib.change_directory("raylib_audio_music_stream")
 
   @raylib.init_window(
     screen_width, screen_height, "raylib [audio] example - music playing (streaming)",

--- a/examples/raylib_audio_sound_loading/main.mbt
+++ b/examples/raylib_audio_sound_loading/main.mbt
@@ -4,7 +4,7 @@ fn main {
   let screen_width = 800
   let screen_height = 450
 
-  let _ = @raylib.change_directory("examples/raylib_audio_sound_loading")
+  let _ = @raylib.change_directory("raylib_audio_sound_loading")
 
   @raylib.init_window(
     screen_width, screen_height, "raylib [audio] example - sound loading and playing",

--- a/examples/raylib_audio_sound_multi/main.mbt
+++ b/examples/raylib_audio_sound_multi/main.mbt
@@ -5,7 +5,7 @@ fn main {
   let screen_height = 450
   let max_sounds = 10
 
-  let _ = @raylib.change_directory("examples/raylib_audio_sound_multi")
+  let _ = @raylib.change_directory("raylib_audio_sound_multi")
 
   @raylib.init_window(
     screen_width, screen_height, "raylib [audio] example - playing sound multiple times",

--- a/examples/raylib_core_vr_simulator/main.mbt
+++ b/examples/raylib_core_vr_simulator/main.mbt
@@ -22,7 +22,7 @@ fn main {
   @raylib.init_window(
     screen_width, screen_height, "raylib [core] example - vr simulator",
   )
-  let _ = @raylib.change_directory("examples/raylib_core_vr_simulator")
+  let _ = @raylib.change_directory("raylib_core_vr_simulator")
 
   // VR device parameters definition
   let device = @raylib.VrDeviceInfo::new(

--- a/examples/raylib_models_animation/main.mbt
+++ b/examples/raylib_models_animation/main.mbt
@@ -19,7 +19,7 @@ fn main {
   // Load the animated model mesh and basic data
   // NOTE: Requires resources/models/iqm/guy.iqm, guytex.png, and guyanim.iqm
   // to be placed in the example directory.
-  let _ = @raylib.change_directory("examples/raylib_models_animation")
+  let _ = @raylib.change_directory("raylib_models_animation")
   let model = @raylib.load_model("resources/models/iqm/guy.iqm")
   let texture = @raylib.load_texture("resources/models/iqm/guytex.png")
   @raylib.set_model_material_texture(

--- a/examples/raylib_models_bone_socket/main.mbt
+++ b/examples/raylib_models_bone_socket/main.mbt
@@ -17,7 +17,7 @@ fn main {
   )
 
   // Load gltf model
-  let _ = @raylib.change_directory("examples/raylib_models_bone_socket")
+  let _ = @raylib.change_directory("raylib_models_bone_socket")
   let character_model = @raylib.load_model("resources/models/gltf/greenman.glb")
   let equip_model : FixedArray[_] = [
     @raylib.load_model("resources/models/gltf/greenman_hat.glb"),

--- a/examples/raylib_models_cubicmap/main.mbt
+++ b/examples/raylib_models_cubicmap/main.mbt
@@ -19,7 +19,7 @@ fn main {
   // Load cubicmap image (RAM)
   // NOTE: Requires resources/cubicmap.png and resources/cubicmap_atlas.png
   // to be placed in the example directory.
-  let _ = @raylib.change_directory("examples/raylib_models_cubicmap")
+  let _ = @raylib.change_directory("raylib_models_cubicmap")
   let image = @raylib.load_image("resources/cubicmap.png")
   let cubicmap = @raylib.load_texture_from_image(image)
 

--- a/examples/raylib_models_first_person_maze/main.mbt
+++ b/examples/raylib_models_first_person_maze/main.mbt
@@ -19,7 +19,7 @@ fn main {
   // Load cubicmap image (RAM)
   // NOTE: Requires resources/cubicmap.png and resources/cubicmap_atlas.png
   // to be placed in the example directory.
-  let _ = @raylib.change_directory("examples/raylib_models_first_person_maze")
+  let _ = @raylib.change_directory("raylib_models_first_person_maze")
   let im_map = @raylib.load_image("resources/cubicmap.png")
   let cubicmap = @raylib.load_texture_from_image(im_map)
   let map_width = @raylib.image_width(im_map)

--- a/examples/raylib_models_gpu_skinning/main.mbt
+++ b/examples/raylib_models_gpu_skinning/main.mbt
@@ -17,7 +17,7 @@ fn main {
   )
 
   // Load gltf model
-  let _ = @raylib.change_directory("examples/raylib_models_gpu_skinning")
+  let _ = @raylib.change_directory("raylib_models_gpu_skinning")
   let character_model = @raylib.load_model("resources/models/gltf/greenman.glb")
 
   // Load skinning shader

--- a/examples/raylib_models_heightmap/main.mbt
+++ b/examples/raylib_models_heightmap/main.mbt
@@ -19,7 +19,7 @@ fn main {
   // Load heightmap image (RAM)
   // NOTE: Requires resources/heightmap.png to be placed in the example directory.
   // You can use any grayscale PNG image as a heightmap.
-  let _ = @raylib.change_directory("examples/raylib_models_heightmap")
+  let _ = @raylib.change_directory("raylib_models_heightmap")
   let image = @raylib.load_image("resources/heightmap.png")
   let texture = @raylib.load_texture_from_image(image)
 

--- a/examples/raylib_models_loading/main.mbt
+++ b/examples/raylib_models_loading/main.mbt
@@ -19,7 +19,7 @@ fn main {
   // Load model
   // NOTE: Requires resources/models/obj/castle.obj and castle_diffuse.png
   // to be placed in the example directory, OR drag-and-drop model files at runtime.
-  let _ = @raylib.change_directory("examples/raylib_models_loading")
+  let _ = @raylib.change_directory("raylib_models_loading")
   let mut model = @raylib.load_model("resources/models/obj/castle.obj")
   let mut texture = @raylib.load_texture(
     "resources/models/obj/castle_diffuse.png",

--- a/examples/raylib_models_loading_gltf/main.mbt
+++ b/examples/raylib_models_loading_gltf/main.mbt
@@ -18,7 +18,7 @@ fn main {
 
   // Load gltf model
   // NOTE: Requires resources/models/gltf/robot.glb to be placed in the example directory.
-  let _ = @raylib.change_directory("examples/raylib_models_loading_gltf")
+  let _ = @raylib.change_directory("raylib_models_loading_gltf")
   let model = @raylib.load_model("resources/models/gltf/robot.glb")
   let position = @raylib.Vector3::new(0.0, 0.0, 0.0)
 

--- a/examples/raylib_models_loading_m3d/main.mbt
+++ b/examples/raylib_models_loading_m3d/main.mbt
@@ -23,7 +23,7 @@ fn main {
   let mut anim_playing = false // Store anim state, what to draw
 
   // Load model
-  let _ = @raylib.change_directory("examples/raylib_models_loading_m3d")
+  let _ = @raylib.change_directory("raylib_models_loading_m3d")
   let model = @raylib.load_model("resources/models/m3d/cesium_man.m3d")
 
   // Load animations

--- a/examples/raylib_models_loading_vox/main.mbt
+++ b/examples/raylib_models_loading_vox/main.mbt
@@ -149,7 +149,7 @@ fn main {
   let screen_height = 450
   let max_vox_files = 4
 
-  let _ = @raylib.change_directory("examples/raylib_models_loading_vox")
+  let _ = @raylib.change_directory("raylib_models_loading_vox")
 
   let vox_file_names = [
     "resources/models/vox/chr_knight.vox", "resources/models/vox/chr_sword.vox",

--- a/examples/raylib_models_mesh_picking/main.mbt
+++ b/examples/raylib_models_mesh_picking/main.mbt
@@ -9,7 +9,7 @@ fn main {
   @raylib.init_window(
     screen_width, screen_height, "raylib [models] example - mesh picking",
   )
-  let _ = @raylib.change_directory("examples/raylib_models_mesh_picking")
+  let _ = @raylib.change_directory("raylib_models_mesh_picking")
   // Define the camera to look into our 3d world
   let mut camera = @raylib.Camera3D::new(
     @raylib.Vector3::new(20.0, 20.0, 20.0),

--- a/examples/raylib_models_skybox/main.mbt
+++ b/examples/raylib_models_skybox/main.mbt
@@ -16,7 +16,7 @@ fn main {
   @raylib.init_window(
     screen_width, screen_height, "raylib [models] example - skybox loading and drawing",
   )
-  let _ = @raylib.change_directory("examples/raylib_models_skybox")
+  let _ = @raylib.change_directory("raylib_models_skybox")
 
   // Define the camera to look into our 3d world
   let mut camera = @raylib.Camera3D::new(

--- a/examples/raylib_models_yaw_pitch_roll/main.mbt
+++ b/examples/raylib_models_yaw_pitch_roll/main.mbt
@@ -9,7 +9,7 @@ fn main {
   @raylib.init_window(
     screen_width, screen_height, "raylib [models] example - plane rotations (yaw, pitch, roll)",
   )
-  let _ = @raylib.change_directory("examples/raylib_models_yaw_pitch_roll")
+  let _ = @raylib.change_directory("raylib_models_yaw_pitch_roll")
   let camera = @raylib.Camera3D::new(
     @raylib.Vector3::new(0.0, 50.0, -120.0),
     @raylib.Vector3::new(0.0, 0.0, 0.0),

--- a/examples/raylib_shaders_basic_lighting/main.mbt
+++ b/examples/raylib_shaders_basic_lighting/main.mbt
@@ -148,7 +148,7 @@ fn main {
   let screen_width = 800
   let screen_height = 450
 
-  let _ = @raylib.change_directory("examples/raylib_shaders_basic_lighting")
+  let _ = @raylib.change_directory("raylib_shaders_basic_lighting")
 
   @raylib.set_config_flags(@raylib.FlagMsaa4xHint)
   @raylib.init_window(

--- a/examples/raylib_shaders_basic_pbr/main.mbt
+++ b/examples/raylib_shaders_basic_pbr/main.mbt
@@ -202,7 +202,7 @@ fn main {
   let screen_width = 800
   let screen_height = 450
 
-  let _ = @raylib.change_directory("examples/raylib_shaders_basic_pbr")
+  let _ = @raylib.change_directory("raylib_shaders_basic_pbr")
 
   @raylib.set_config_flags(@raylib.FlagMsaa4xHint)
   @raylib.init_window(

--- a/examples/raylib_shaders_color_correction/main.mbt
+++ b/examples/raylib_shaders_color_correction/main.mbt
@@ -18,7 +18,7 @@ fn main {
   let screen_width = 800
   let screen_height = 450
 
-  let _ = @raylib.change_directory("examples/raylib_shaders_color_correction")
+  let _ = @raylib.change_directory("raylib_shaders_color_correction")
 
   @raylib.init_window(
     screen_width, screen_height, "raylib [shaders] example - color correction",

--- a/examples/raylib_shaders_custom_uniform/main.mbt
+++ b/examples/raylib_shaders_custom_uniform/main.mbt
@@ -9,7 +9,7 @@ fn main {
   let screen_width = 800
   let screen_height = 450
 
-  let _ = @raylib.change_directory("examples/raylib_shaders_custom_uniform")
+  let _ = @raylib.change_directory("raylib_shaders_custom_uniform")
 
   @raylib.set_config_flags(@raylib.FlagMsaa4xHint)
   @raylib.init_window(

--- a/examples/raylib_shaders_deferred_render/main.mbt
+++ b/examples/raylib_shaders_deferred_render/main.mbt
@@ -187,7 +187,7 @@ fn main {
   let screen_width = 800
   let screen_height = 450
 
-  let _ = @raylib.change_directory("examples/raylib_shaders_deferred_render")
+  let _ = @raylib.change_directory("raylib_shaders_deferred_render")
 
   @raylib.init_window(
     screen_width, screen_height, "raylib [shaders] example - deferred render",

--- a/examples/raylib_shaders_eratosthenes/main.mbt
+++ b/examples/raylib_shaders_eratosthenes/main.mbt
@@ -3,7 +3,7 @@ fn main {
   // Initialization
   let screen_width = 800
   let screen_height = 450
-  let _ = @raylib.change_directory("examples/raylib_shaders_eratosthenes")
+  let _ = @raylib.change_directory("raylib_shaders_eratosthenes")
   @raylib.init_window(
     screen_width, screen_height, "raylib [shaders] example - eratosthenes sieve",
   )

--- a/examples/raylib_shaders_fog/main.mbt
+++ b/examples/raylib_shaders_fog/main.mbt
@@ -169,7 +169,7 @@ fn main {
   let screen_width = 800
   let screen_height = 450
 
-  let _ = @raylib.change_directory("examples/raylib_shaders_fog")
+  let _ = @raylib.change_directory("raylib_shaders_fog")
 
   @raylib.set_config_flags(@raylib.FlagMsaa4xHint)
   @raylib.init_window(

--- a/examples/raylib_shaders_hot_reloading/main.mbt
+++ b/examples/raylib_shaders_hot_reloading/main.mbt
@@ -19,7 +19,7 @@ fn main {
   let screen_width = 800
   let screen_height = 450
 
-  let _ = @raylib.change_directory("examples/raylib_shaders_hot_reloading")
+  let _ = @raylib.change_directory("raylib_shaders_hot_reloading")
 
   @raylib.init_window(
     screen_width, screen_height, "raylib [shaders] example - hot reloading",

--- a/examples/raylib_shaders_hybrid_render/main.mbt
+++ b/examples/raylib_shaders_hybrid_render/main.mbt
@@ -19,7 +19,7 @@ fn main {
   let screen_width = 800
   let screen_height = 450
 
-  let _ = @raylib.change_directory("examples/raylib_shaders_hybrid_render")
+  let _ = @raylib.change_directory("raylib_shaders_hybrid_render")
 
   @raylib.init_window(
     screen_width, screen_height, "raylib [shaders] example - write depth buffer",

--- a/examples/raylib_shaders_julia_set/main.mbt
+++ b/examples/raylib_shaders_julia_set/main.mbt
@@ -20,7 +20,7 @@ fn main {
   let screen_width = 800
   let screen_height = 450
 
-  let _ = @raylib.change_directory("examples/raylib_shaders_julia_set")
+  let _ = @raylib.change_directory("raylib_shaders_julia_set")
 
   @raylib.init_window(
     screen_width, screen_height, "raylib [shaders] example - julia set",

--- a/examples/raylib_shaders_mesh_instancing/main.mbt
+++ b/examples/raylib_shaders_mesh_instancing/main.mbt
@@ -136,7 +136,7 @@ fn main {
   let screen_height = 450
   let max_instances = 10000
 
-  let _ = @raylib.change_directory("examples/raylib_shaders_mesh_instancing")
+  let _ = @raylib.change_directory("raylib_shaders_mesh_instancing")
 
   @raylib.set_config_flags(@raylib.FlagMsaa4xHint)
   @raylib.init_window(

--- a/examples/raylib_shaders_model_shader/main.mbt
+++ b/examples/raylib_shaders_model_shader/main.mbt
@@ -7,7 +7,7 @@ fn main {
   @raylib.init_window(
     screen_width, screen_height, "raylib [shaders] example - model shader",
   )
-  let _ = @raylib.change_directory("examples/raylib_shaders_model_shader")
+  let _ = @raylib.change_directory("raylib_shaders_model_shader")
   // Define the camera to look into our 3d world
   let mut camera = @raylib.Camera3D::new(
     @raylib.Vector3::new(4.0, 4.0, 4.0),

--- a/examples/raylib_shaders_multi_sample2d/main.mbt
+++ b/examples/raylib_shaders_multi_sample2d/main.mbt
@@ -15,7 +15,7 @@ fn main {
   let screen_width = 800
   let screen_height = 450
   @raylib.init_window(screen_width, screen_height, "raylib - multiple sample2D")
-  let _ = @raylib.change_directory("examples/raylib_shaders_multi_sample2d")
+  let _ = @raylib.change_directory("raylib_shaders_multi_sample2d")
   let im_red = @raylib.gen_image_color(
     800,
     450,

--- a/examples/raylib_shaders_palette_switch/main.mbt
+++ b/examples/raylib_shaders_palette_switch/main.mbt
@@ -20,7 +20,7 @@ fn main {
   @raylib.init_window(
     screen_width, screen_height, "raylib [shaders] example - palette switch",
   )
-  let _ = @raylib.change_directory("examples/raylib_shaders_palette_switch")
+  let _ = @raylib.change_directory("raylib_shaders_palette_switch")
 
   // Load shader
   let shader = @raylib.load_shader(

--- a/examples/raylib_shaders_postprocessing/main.mbt
+++ b/examples/raylib_shaders_postprocessing/main.mbt
@@ -4,7 +4,7 @@ fn main {
   let screen_width = 800
   let screen_height = 450
 
-  let _ = @raylib.change_directory("examples/raylib_shaders_postprocessing")
+  let _ = @raylib.change_directory("raylib_shaders_postprocessing")
 
   @raylib.set_config_flags(@raylib.FlagMsaa4xHint)
   @raylib.init_window(

--- a/examples/raylib_shaders_raymarching/main.mbt
+++ b/examples/raylib_shaders_raymarching/main.mbt
@@ -51,7 +51,7 @@ fn main {
   // Initialization
   let screen_width = 800
   let screen_height = 450
-  let _ = @raylib.change_directory("examples/raylib_shaders_raymarching")
+  let _ = @raylib.change_directory("raylib_shaders_raymarching")
   @raylib.set_config_flags(@raylib.FlagWindowResizable)
   @raylib.init_window(
     screen_width, screen_height, "raylib [shaders] example - raymarching rendering",

--- a/examples/raylib_shaders_shadowmap/main.mbt
+++ b/examples/raylib_shaders_shadowmap/main.mbt
@@ -54,7 +54,7 @@ fn main {
   let screen_width = 800
   let screen_height = 450
 
-  let _ = @raylib.change_directory("examples/raylib_shaders_shadowmap")
+  let _ = @raylib.change_directory("raylib_shaders_shadowmap")
 
   @raylib.set_config_flags(@raylib.FlagMsaa4xHint)
   @raylib.init_window(

--- a/examples/raylib_shaders_shapes_textures/main.mbt
+++ b/examples/raylib_shaders_shapes_textures/main.mbt
@@ -4,7 +4,7 @@ fn main {
   let screen_width = 800
   let screen_height = 450
 
-  let _ = @raylib.change_directory("examples/raylib_shaders_shapes_textures")
+  let _ = @raylib.change_directory("raylib_shaders_shapes_textures")
 
   @raylib.init_window(
     screen_width, screen_height, "raylib [shaders] example - shapes and textures shaders",

--- a/examples/raylib_shaders_simple_mask/main.mbt
+++ b/examples/raylib_shaders_simple_mask/main.mbt
@@ -13,7 +13,7 @@ fn main {
   // Initialization
   let screen_width = 800
   let screen_height = 450
-  let _ = @raylib.change_directory("examples/raylib_shaders_simple_mask")
+  let _ = @raylib.change_directory("raylib_shaders_simple_mask")
   @raylib.init_window(
     screen_width, screen_height, "raylib [shaders] example - simple mask",
   )

--- a/examples/raylib_shaders_spotlight/main.mbt
+++ b/examples/raylib_shaders_spotlight/main.mbt
@@ -94,7 +94,7 @@ fn main {
   let screen_height = 450
   let max_spots = 3
   let max_stars = 400
-  let _ = @raylib.change_directory("examples/raylib_shaders_spotlight")
+  let _ = @raylib.change_directory("raylib_shaders_spotlight")
   @raylib.init_window(
     screen_width, screen_height, "raylib [shaders] example - spotlight rendering",
   )

--- a/examples/raylib_shaders_texture_drawing/main.mbt
+++ b/examples/raylib_shaders_texture_drawing/main.mbt
@@ -17,7 +17,7 @@ fn main {
   @raylib.init_window(
     screen_width, screen_height, "raylib [shaders] example - texture drawing",
   )
-  let _ = @raylib.change_directory("examples/raylib_shaders_texture_drawing")
+  let _ = @raylib.change_directory("raylib_shaders_texture_drawing")
   let im_blank = @raylib.gen_image_color(1024, 1024, @raylib.blank)
   let texture = @raylib.load_texture_from_image(im_blank)
   @raylib.unload_image(im_blank)

--- a/examples/raylib_shaders_texture_outline/main.mbt
+++ b/examples/raylib_shaders_texture_outline/main.mbt
@@ -59,7 +59,7 @@ fn main {
   @raylib.init_window(
     screen_width, screen_height, "raylib [shaders] example - Apply an outline to a texture",
   )
-  let _ = @raylib.change_directory("examples/raylib_shaders_texture_outline")
+  let _ = @raylib.change_directory("raylib_shaders_texture_outline")
   let texture = @raylib.load_texture("resources/fudesumi.png")
   let shdr_outline = @raylib.load_shader(
     "", "resources/shaders/glsl330/outline.fs",

--- a/examples/raylib_shaders_texture_tiling/main.mbt
+++ b/examples/raylib_shaders_texture_tiling/main.mbt
@@ -22,7 +22,7 @@ fn main {
   @raylib.init_window(
     screen_width, screen_height, "raylib [shaders] example - texture tiling",
   )
-  let _ = @raylib.change_directory("examples/raylib_shaders_texture_tiling")
+  let _ = @raylib.change_directory("raylib_shaders_texture_tiling")
   // Define the camera to look into our 3d world
   let mut camera = @raylib.Camera3D::new(
     @raylib.Vector3::new(4.0, 4.0, 4.0),

--- a/examples/raylib_shaders_texture_waves/main.mbt
+++ b/examples/raylib_shaders_texture_waves/main.mbt
@@ -20,7 +20,7 @@ fn main {
   let screen_width = 800
   let screen_height = 450
 
-  let _ = @raylib.change_directory("examples/raylib_shaders_texture_waves")
+  let _ = @raylib.change_directory("raylib_shaders_texture_waves")
 
   @raylib.init_window(
     screen_width, screen_height, "raylib [shaders] example - texture waves",

--- a/examples/raylib_shaders_vertex_displacement/main.mbt
+++ b/examples/raylib_shaders_vertex_displacement/main.mbt
@@ -16,7 +16,7 @@ fn main {
   let screen_height = 450
 
   let _ = @raylib.change_directory(
-    "examples/raylib_shaders_vertex_displacement",
+    "raylib_shaders_vertex_displacement",
   )
 
   @raylib.init_window(

--- a/examples/raylib_shaders_write_depth/main.mbt
+++ b/examples/raylib_shaders_write_depth/main.mbt
@@ -4,7 +4,7 @@ fn main {
   let screen_width = 800
   let screen_height = 450
 
-  let _ = @raylib.change_directory("examples/raylib_shaders_write_depth")
+  let _ = @raylib.change_directory("raylib_shaders_write_depth")
 
   @raylib.init_window(
     screen_width, screen_height, "raylib [shaders] example - write depth buffer",

--- a/examples/raylib_text_codepoints_loading/main.mbt
+++ b/examples/raylib_text_codepoints_loading/main.mbt
@@ -21,7 +21,7 @@ fn main {
   // Initialization
   let screen_width = 800
   let screen_height = 450
-  let _ = @raylib.change_directory("examples/raylib_text_codepoints_loading")
+  let _ = @raylib.change_directory("raylib_text_codepoints_loading")
   @raylib.init_window(
     screen_width, screen_height, "raylib [text] example - codepoints loading",
   )

--- a/examples/raylib_text_font_filters/main.mbt
+++ b/examples/raylib_text_font_filters/main.mbt
@@ -3,7 +3,7 @@ fn main {
   // Initialization
   let screen_width = 800
   let screen_height = 450
-  let _ = @raylib.change_directory("examples/raylib_text_font_filters")
+  let _ = @raylib.change_directory("raylib_text_font_filters")
   @raylib.init_window(
     screen_width, screen_height, "raylib [text] example - font filters",
   )

--- a/examples/raylib_text_font_loading/main.mbt
+++ b/examples/raylib_text_font_loading/main.mbt
@@ -3,7 +3,7 @@ fn main {
   // Initialization
   let screen_width = 800
   let screen_height = 450
-  let _ = @raylib.change_directory("examples/raylib_text_font_loading")
+  let _ = @raylib.change_directory("raylib_text_font_loading")
   @raylib.init_window(
     screen_width, screen_height, "raylib [text] example - font loading",
   )

--- a/examples/raylib_text_font_sdf/main.mbt
+++ b/examples/raylib_text_font_sdf/main.mbt
@@ -3,7 +3,7 @@ fn main {
   // Initialization
   let screen_width = 800
   let screen_height = 450
-  let _ = @raylib.change_directory("examples/raylib_text_font_sdf")
+  let _ = @raylib.change_directory("raylib_text_font_sdf")
   @raylib.init_window(
     screen_width, screen_height, "raylib [text] example - SDF fonts",
   )

--- a/examples/raylib_text_font_spritefont/main.mbt
+++ b/examples/raylib_text_font_spritefont/main.mbt
@@ -3,7 +3,7 @@ fn main {
   // Initialization
   let screen_width = 800
   let screen_height = 450
-  let _ = @raylib.change_directory("examples/raylib_text_font_spritefont")
+  let _ = @raylib.change_directory("raylib_text_font_spritefont")
   @raylib.init_window(
     screen_width, screen_height, "raylib [text] example - sprite font loading",
   )

--- a/examples/raylib_text_raylib_fonts/main.mbt
+++ b/examples/raylib_text_raylib_fonts/main.mbt
@@ -3,7 +3,7 @@ fn main {
   // Initialization
   let screen_width = 800
   let screen_height = 450
-  let _ = @raylib.change_directory("examples/raylib_text_raylib_fonts")
+  let _ = @raylib.change_directory("raylib_text_raylib_fonts")
   @raylib.init_window(
     screen_width, screen_height, "raylib [text] example - raylib fonts",
   )

--- a/examples/raylib_text_unicode/main.mbt
+++ b/examples/raylib_text_unicode/main.mbt
@@ -367,7 +367,7 @@ fn main {
   // Initialization
   let screen_width = 800
   let screen_height = 450
-  let _ = @raylib.change_directory("examples/raylib_text_unicode")
+  let _ = @raylib.change_directory("raylib_text_unicode")
   @raylib.set_config_flags(@raylib.FlagMsaa4xHint | @raylib.FlagVsyncHint)
   @raylib.init_window(
     screen_width, screen_height, "raylib [text] example - unicode",

--- a/examples/raylib_textures_background_scrolling/main.mbt
+++ b/examples/raylib_textures_background_scrolling/main.mbt
@@ -4,7 +4,7 @@ fn main {
   let screen_width = 800
   let screen_height = 450
   let _ = @raylib.change_directory(
-    "examples/raylib_textures_background_scrolling",
+    "raylib_textures_background_scrolling",
   )
   @raylib.init_window(
     screen_width, screen_height, "raylib [textures] example - background scrolling",

--- a/examples/raylib_textures_blend_modes/main.mbt
+++ b/examples/raylib_textures_blend_modes/main.mbt
@@ -3,7 +3,7 @@ fn main {
   // Initialization
   let screen_width = 800
   let screen_height = 450
-  let _ = @raylib.change_directory("examples/raylib_textures_blend_modes")
+  let _ = @raylib.change_directory("raylib_textures_blend_modes")
   @raylib.init_window(
     screen_width, screen_height, "raylib [textures] example - blend modes",
   )

--- a/examples/raylib_textures_bunnymark/main.mbt
+++ b/examples/raylib_textures_bunnymark/main.mbt
@@ -12,7 +12,7 @@ fn main {
   let screen_height = 450
   let max_bunnies = 50000
   let max_batch_elements = 8192
-  let _ = @raylib.change_directory("examples/raylib_textures_bunnymark")
+  let _ = @raylib.change_directory("raylib_textures_bunnymark")
   @raylib.init_window(
     screen_width, screen_height, "raylib [textures] example - bunnymark",
   )

--- a/examples/raylib_textures_draw_tiled/main.mbt
+++ b/examples/raylib_textures_draw_tiled/main.mbt
@@ -212,7 +212,7 @@ fn main {
   // Initialization
   let screen_width = 800
   let screen_height = 450
-  let _ = @raylib.change_directory("examples/raylib_textures_draw_tiled")
+  let _ = @raylib.change_directory("raylib_textures_draw_tiled")
   @raylib.set_config_flags(@raylib.FlagWindowResizable)
   @raylib.init_window(
     screen_width, screen_height, "raylib [textures] example - Draw part of a texture tiled",

--- a/examples/raylib_textures_gif_player/main.mbt
+++ b/examples/raylib_textures_gif_player/main.mbt
@@ -5,7 +5,7 @@ fn main {
   let screen_height = 450
   let max_frame_delay = 20
   let min_frame_delay = 1
-  let _ = @raylib.change_directory("examples/raylib_textures_gif_player")
+  let _ = @raylib.change_directory("raylib_textures_gif_player")
   @raylib.init_window(
     screen_width, screen_height, "raylib [textures] example - gif playing",
   )

--- a/examples/raylib_textures_image_channel/main.mbt
+++ b/examples/raylib_textures_image_channel/main.mbt
@@ -3,7 +3,7 @@ fn main {
   // Initialization
   let screen_width = 800
   let screen_height = 450
-  let _ = @raylib.change_directory("examples/raylib_textures_image_channel")
+  let _ = @raylib.change_directory("raylib_textures_image_channel")
   @raylib.init_window(
     screen_width, screen_height, "raylib [textures] example - extract channel from image",
   )

--- a/examples/raylib_textures_image_drawing/main.mbt
+++ b/examples/raylib_textures_image_drawing/main.mbt
@@ -3,7 +3,7 @@ fn main {
   // Initialization
   let screen_width = 800
   let screen_height = 450
-  let _ = @raylib.change_directory("examples/raylib_textures_image_drawing")
+  let _ = @raylib.change_directory("raylib_textures_image_drawing")
   @raylib.init_window(
     screen_width, screen_height, "raylib [textures] example - image drawing",
   )

--- a/examples/raylib_textures_image_kernel/main.mbt
+++ b/examples/raylib_textures_image_kernel/main.mbt
@@ -30,7 +30,7 @@ fn main {
   // Initialization
   let screen_width = 800
   let screen_height = 450
-  let _ = @raylib.change_directory("examples/raylib_textures_image_kernel")
+  let _ = @raylib.change_directory("raylib_textures_image_kernel")
   @raylib.init_window(
     screen_width, screen_height, "raylib [textures] example - image convolution",
   )

--- a/examples/raylib_textures_image_loading/main.mbt
+++ b/examples/raylib_textures_image_loading/main.mbt
@@ -4,7 +4,7 @@ fn main {
   let screen_width = 800
   let screen_height = 450
 
-  let _ = @raylib.change_directory("examples/raylib_textures_image_loading")
+  let _ = @raylib.change_directory("raylib_textures_image_loading")
 
   @raylib.init_window(
     screen_width, screen_height, "raylib [textures] example - image loading",

--- a/examples/raylib_textures_image_processing/main.mbt
+++ b/examples/raylib_textures_image_processing/main.mbt
@@ -4,7 +4,7 @@ fn main {
   let screen_width = 800
   let screen_height = 450
   let num_processes = 9
-  let _ = @raylib.change_directory("examples/raylib_textures_image_processing")
+  let _ = @raylib.change_directory("raylib_textures_image_processing")
   @raylib.init_window(
     screen_width, screen_height, "raylib [textures] example - image processing",
   )

--- a/examples/raylib_textures_image_rotate/main.mbt
+++ b/examples/raylib_textures_image_rotate/main.mbt
@@ -4,7 +4,7 @@ fn main {
   let screen_width = 800
   let screen_height = 450
   let num_textures = 3
-  let _ = @raylib.change_directory("examples/raylib_textures_image_rotate")
+  let _ = @raylib.change_directory("raylib_textures_image_rotate")
   @raylib.init_window(
     screen_width, screen_height, "raylib [textures] example - texture rotation",
   )

--- a/examples/raylib_textures_image_text/main.mbt
+++ b/examples/raylib_textures_image_text/main.mbt
@@ -3,7 +3,7 @@ fn main {
   // Initialization
   let screen_width = 800
   let screen_height = 450
-  let _ = @raylib.change_directory("examples/raylib_textures_image_text")
+  let _ = @raylib.change_directory("raylib_textures_image_text")
   @raylib.init_window(
     screen_width, screen_height, "raylib [texture] example - image text drawing",
   )

--- a/examples/raylib_textures_logo_raylib/main.mbt
+++ b/examples/raylib_textures_logo_raylib/main.mbt
@@ -4,7 +4,7 @@ fn main {
   let screen_width = 800
   let screen_height = 450
 
-  let _ = @raylib.change_directory("examples/raylib_textures_logo_raylib")
+  let _ = @raylib.change_directory("raylib_textures_logo_raylib")
 
   @raylib.init_window(
     screen_width, screen_height, "raylib [textures] example - texture loading and drawing",

--- a/examples/raylib_textures_npatch_drawing/main.mbt
+++ b/examples/raylib_textures_npatch_drawing/main.mbt
@@ -3,7 +3,7 @@ fn main {
   // Initialization
   let screen_width = 800
   let screen_height = 450
-  let _ = @raylib.change_directory("examples/raylib_textures_npatch_drawing")
+  let _ = @raylib.change_directory("raylib_textures_npatch_drawing")
   @raylib.init_window(
     screen_width, screen_height, "raylib [textures] example - N-patch drawing",
   )

--- a/examples/raylib_textures_particles_blending/main.mbt
+++ b/examples/raylib_textures_particles_blending/main.mbt
@@ -15,7 +15,7 @@ fn main {
   let screen_height = 450
   let max_particles = 200
   let _ = @raylib.change_directory(
-    "examples/raylib_textures_particles_blending",
+    "raylib_textures_particles_blending",
   )
   @raylib.init_window(
     screen_width, screen_height, "raylib [textures] example - particles blending",

--- a/examples/raylib_textures_raw_data/main.mbt
+++ b/examples/raylib_textures_raw_data/main.mbt
@@ -3,7 +3,7 @@ fn main {
   // Initialization
   let screen_width = 800
   let screen_height = 450
-  let _ = @raylib.change_directory("examples/raylib_textures_raw_data")
+  let _ = @raylib.change_directory("raylib_textures_raw_data")
   @raylib.init_window(
     screen_width, screen_height, "raylib [textures] example - texture from raw data",
   )

--- a/examples/raylib_textures_sprite_anim/main.mbt
+++ b/examples/raylib_textures_sprite_anim/main.mbt
@@ -5,7 +5,7 @@ fn main {
   let screen_height = 450
   let max_frame_speed = 15
   let min_frame_speed = 1
-  let _ = @raylib.change_directory("examples/raylib_textures_sprite_anim")
+  let _ = @raylib.change_directory("raylib_textures_sprite_anim")
   @raylib.init_window(
     screen_width, screen_height, "raylib [texture] example - sprite anim",
   )

--- a/examples/raylib_textures_sprite_button/main.mbt
+++ b/examples/raylib_textures_sprite_button/main.mbt
@@ -4,7 +4,7 @@ fn main {
   let screen_width = 800
   let screen_height = 450
   let num_frames = 3
-  let _ = @raylib.change_directory("examples/raylib_textures_sprite_button")
+  let _ = @raylib.change_directory("raylib_textures_sprite_button")
   @raylib.init_window(
     screen_width, screen_height, "raylib [textures] example - sprite button",
   )

--- a/examples/raylib_textures_sprite_explosion/main.mbt
+++ b/examples/raylib_textures_sprite_explosion/main.mbt
@@ -5,7 +5,7 @@ fn main {
   let screen_height = 450
   let num_frames_per_line = 5
   let num_lines = 5
-  let _ = @raylib.change_directory("examples/raylib_textures_sprite_explosion")
+  let _ = @raylib.change_directory("raylib_textures_sprite_explosion")
   @raylib.init_window(
     screen_width, screen_height, "raylib [textures] example - sprite explosion",
   )

--- a/examples/raylib_textures_srcrec_dstrec/main.mbt
+++ b/examples/raylib_textures_srcrec_dstrec/main.mbt
@@ -3,7 +3,7 @@ fn main {
   // Initialization
   let screen_width = 800
   let screen_height = 450
-  let _ = @raylib.change_directory("examples/raylib_textures_srcrec_dstrec")
+  let _ = @raylib.change_directory("raylib_textures_srcrec_dstrec")
   @raylib.init_window(
     screen_width, screen_height, "raylib [textures] examples - texture source and destination rectangles",
   )

--- a/examples/raylib_textures_to_image/main.mbt
+++ b/examples/raylib_textures_to_image/main.mbt
@@ -4,7 +4,7 @@ fn main {
   let screen_width = 800
   let screen_height = 450
 
-  let _ = @raylib.change_directory("examples/raylib_textures_to_image")
+  let _ = @raylib.change_directory("raylib_textures_to_image")
 
   @raylib.init_window(
     screen_width, screen_height, "raylib [textures] example - texture to image",


### PR DESCRIPTION
## Summary
- moon run sets cwd to the module root (examples/), not the repo root, so change_directory(examples/raylib_...) resolved to examples/examples/raylib_... which does not exist
- Removed the examples/ prefix from all 72 change_directory calls so resource files (textures, fonts, shaders, audio) load correctly
- Verified on Windows 11 with MSVC 19.44 / Intel UHD Graphics / OpenGL 3.3

## Test plan
- [x] moon check --target native passes
- [x] Tested 11 examples across all raylib subsystems (core, shapes, textures, text, models, audio, shaders)
- [x] Resource-dependent examples (bunnymark, font_loading, sound_loading, shaders_basic_lighting) now load files successfully