### PR TITLE
fix: replace deprecated Int.lsr with UInt >> in hash_int

### DIFF
--- a/examples/raylib_voxel_world_3d/types/utils.mbt
+++ b/examples/raylib_voxel_world_3d/types/utils.mbt
@@ -115,16 +115,17 @@ pub fn smoothstep(edge0 : Float, edge1 : Float, x : Float) -> Float {
 
 ///|
 fn hash_int(x_in : Int) -> Int {
-  let mut x = x_in
-  x = x ^ (x.reinterpret_as_uint() >> 16).reinterpret_as_int()
-  x = x * 73244475 // 0x45d9f3b
-  x = x ^ (x.reinterpret_as_uint() >> 16).reinterpret_as_int()
-  x = x * 73244475
-  x = x ^ (x.reinterpret_as_uint() >> 16).reinterpret_as_int()
-  if x < 0 {
-    -x
+  let mut x = x_in.reinterpret_as_uint()
+  x = x ^ (x >> 16)
+  x = x * 73244475U // 0x45d9f3b
+  x = x ^ (x >> 16)
+  x = x * 73244475U
+  x = x ^ (x >> 16)
+  let result = x.reinterpret_as_int()
+  if result < 0 {
+    -result
   } else {
-    x
+    result
   }
 }
 


### PR DESCRIPTION
## Summary
- Refactored `hash_int` in `raylib_voxel_world_3d/types/utils.mbt` to operate entirely in `UInt` space instead of per-expression `reinterpret_as_uint()`/`reinterpret_as_int()` round-trips
- Eliminates redundant casts — one `reinterpret_as_uint()` at entry, one `reinterpret_as_int()` at exit
- Behavior is identical across all 2^32 inputs (verified by codex review)

## Test plan
- [x] `moon check --target native` passes with zero deprecated warnings
- [x] `moon build --target native raylib_voxel_world_3d/` builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbit-community/tonyfettes-raylib/pull/29" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
