### PR TITLE
chore: release v0.2.3

### DIFF
--- a/moon.mod.json
+++ b/moon.mod.json
@@ -1,6 +1,6 @@
 {
   "name": "tonyfettes/raylib",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "readme": "README.md",
   "repository": "https://github.com/moonbit-community/tonyfettes-raylib",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump version to 0.2.3
- Includes fix for Bool-returning FFI stubs (int32_t wrappers) and warning fixes

## Checklist
- [x] `moon check --target native` passes
- [x] `moon publish --dry-run` returns 202
- [x] `moon package --list` confirms no dev files included