### PR TITLE
[codex] Mark raylib packages native-only

### DIFF
--- a/examples/audio/audio_mixed_processor/moon.pkg
+++ b/examples/audio/audio_mixed_processor/moon.pkg
@@ -6,3 +6,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/audio/audio_module_playing/moon.pkg
+++ b/examples/audio/audio_module_playing/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/audio/audio_music_stream/moon.pkg
+++ b/examples/audio/audio_music_stream/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/audio/audio_raw_stream/moon.pkg
+++ b/examples/audio/audio_raw_stream/moon.pkg
@@ -6,3 +6,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/audio/audio_sound_loading/moon.pkg
+++ b/examples/audio/audio_sound_loading/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/audio/audio_sound_multi/moon.pkg
+++ b/examples/audio/audio_sound_multi/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/audio/audio_stream_effects/moon.pkg
+++ b/examples/audio/audio_stream_effects/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/core/core_2d_camera/moon.pkg
+++ b/examples/core/core_2d_camera/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/core/core_2d_camera_mouse_zoom/moon.pkg
+++ b/examples/core/core_2d_camera_mouse_zoom/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/core/core_2d_camera_platformer/moon.pkg
+++ b/examples/core/core_2d_camera_platformer/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/core/core_2d_camera_split_screen/moon.pkg
+++ b/examples/core/core_2d_camera_split_screen/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/core/core_3d_camera_first_person/moon.pkg
+++ b/examples/core/core_3d_camera_first_person/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/core/core_3d_camera_free/moon.pkg
+++ b/examples/core/core_3d_camera_free/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/core/core_3d_camera_mode/moon.pkg
+++ b/examples/core/core_3d_camera_mode/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/core/core_3d_camera_split_screen/moon.pkg
+++ b/examples/core/core_3d_camera_split_screen/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/core/core_3d_picking/moon.pkg
+++ b/examples/core/core_3d_picking/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/core/core_automation_events/moon.pkg
+++ b/examples/core/core_automation_events/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/core/core_basic_screen_manager/moon.pkg
+++ b/examples/core/core_basic_screen_manager/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/core/core_basic_window/moon.pkg
+++ b/examples/core/core_basic_window/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/core/core_custom_frame_control/moon.pkg
+++ b/examples/core/core_custom_frame_control/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/core/core_drop_files/moon.pkg
+++ b/examples/core/core_drop_files/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/core/core_input_gamepad/moon.pkg
+++ b/examples/core/core_input_gamepad/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/core/core_input_gamepad_info/moon.pkg
+++ b/examples/core/core_input_gamepad_info/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/core/core_input_gestures/moon.pkg
+++ b/examples/core/core_input_gestures/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/core/core_input_keys/moon.pkg
+++ b/examples/core/core_input_keys/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/core/core_input_mouse/moon.pkg
+++ b/examples/core/core_input_mouse/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/core/core_input_mouse_wheel/moon.pkg
+++ b/examples/core/core_input_mouse_wheel/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/core/core_input_multitouch/moon.pkg
+++ b/examples/core/core_input_multitouch/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/core/core_input_virtual_controls/moon.pkg
+++ b/examples/core/core_input_virtual_controls/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/core/core_random_sequence/moon.pkg
+++ b/examples/core/core_random_sequence/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/core/core_random_values/moon.pkg
+++ b/examples/core/core_random_values/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/core/core_scissor_test/moon.pkg
+++ b/examples/core/core_scissor_test/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/core/core_smooth_pixelperfect/moon.pkg
+++ b/examples/core/core_smooth_pixelperfect/moon.pkg
@@ -6,3 +6,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/core/core_storage_values/moon.pkg
+++ b/examples/core/core_storage_values/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/core/core_vr_simulator/moon.pkg
+++ b/examples/core/core_vr_simulator/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/core/core_window_flags/moon.pkg
+++ b/examples/core/core_window_flags/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/core/core_window_letterbox/moon.pkg
+++ b/examples/core/core_window_letterbox/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/core/core_window_should_close/moon.pkg
+++ b/examples/core/core_window_should_close/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/core/core_world_screen/moon.pkg
+++ b/examples/core/core_world_screen/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/models/models_animation/moon.pkg
+++ b/examples/models/models_animation/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/models/models_billboard/moon.pkg
+++ b/examples/models/models_billboard/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/models/models_bone_socket/moon.pkg
+++ b/examples/models/models_bone_socket/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/models/models_box_collisions/moon.pkg
+++ b/examples/models/models_box_collisions/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/models/models_cubicmap/moon.pkg
+++ b/examples/models/models_cubicmap/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/models/models_draw_cube_texture/moon.pkg
+++ b/examples/models/models_draw_cube_texture/moon.pkg
@@ -6,3 +6,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/models/models_first_person_maze/moon.pkg
+++ b/examples/models/models_first_person_maze/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/models/models_geometric_shapes/moon.pkg
+++ b/examples/models/models_geometric_shapes/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/models/models_gpu_skinning/moon.pkg
+++ b/examples/models/models_gpu_skinning/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/models/models_heightmap/moon.pkg
+++ b/examples/models/models_heightmap/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/models/models_loading/moon.pkg
+++ b/examples/models/models_loading/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/models/models_loading_gltf/moon.pkg
+++ b/examples/models/models_loading_gltf/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/models/models_loading_m3d/moon.pkg
+++ b/examples/models/models_loading_m3d/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/models/models_loading_vox/moon.pkg
+++ b/examples/models/models_loading_vox/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/models/models_mesh_generation/moon.pkg
+++ b/examples/models/models_mesh_generation/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/models/models_mesh_picking/moon.pkg
+++ b/examples/models/models_mesh_picking/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/models/models_orthographic_projection/moon.pkg
+++ b/examples/models/models_orthographic_projection/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/models/models_point_rendering/moon.pkg
+++ b/examples/models/models_point_rendering/moon.pkg
@@ -6,3 +6,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/models/models_rlgl_solar_system/moon.pkg
+++ b/examples/models/models_rlgl_solar_system/moon.pkg
@@ -7,3 +7,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/models/models_skybox/moon.pkg
+++ b/examples/models/models_skybox/moon.pkg
@@ -6,3 +6,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/models/models_waving_cubes/moon.pkg
+++ b/examples/models/models_waving_cubes/moon.pkg
@@ -6,3 +6,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/models/models_yaw_pitch_roll/moon.pkg
+++ b/examples/models/models_yaw_pitch_roll/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/others/easings_testbed/moon.pkg
+++ b/examples/others/easings_testbed/moon.pkg
@@ -6,3 +6,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/others/embedded_files_loading/moon.pkg
+++ b/examples/others/embedded_files_loading/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/others/raygui_demo/moon.pkg
+++ b/examples/others/raygui_demo/moon.pkg
@@ -6,3 +6,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/others/raymath_vector_angle/moon.pkg
+++ b/examples/others/raymath_vector_angle/moon.pkg
@@ -6,3 +6,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/shaders/shaders_basic_lighting/moon.pkg
+++ b/examples/shaders/shaders_basic_lighting/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/shaders/shaders_basic_pbr/moon.pkg
+++ b/examples/shaders/shaders_basic_pbr/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/shaders/shaders_custom_uniform/moon.pkg
+++ b/examples/shaders/shaders_custom_uniform/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/shaders/shaders_deferred_render/moon.pkg
+++ b/examples/shaders/shaders_deferred_render/moon.pkg
@@ -6,3 +6,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/shaders/shaders_eratosthenes/moon.pkg
+++ b/examples/shaders/shaders_eratosthenes/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/shaders/shaders_fog/moon.pkg
+++ b/examples/shaders/shaders_fog/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/shaders/shaders_hot_reloading/moon.pkg
+++ b/examples/shaders/shaders_hot_reloading/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/shaders/shaders_hybrid_render/moon.pkg
+++ b/examples/shaders/shaders_hybrid_render/moon.pkg
@@ -7,3 +7,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/shaders/shaders_julia_set/moon.pkg
+++ b/examples/shaders/shaders_julia_set/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/shaders/shaders_lightmap/moon.pkg
+++ b/examples/shaders/shaders_lightmap/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/shaders/shaders_mesh_instancing/moon.pkg
+++ b/examples/shaders/shaders_mesh_instancing/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/shaders/shaders_model_shader/moon.pkg
+++ b/examples/shaders/shaders_model_shader/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/shaders/shaders_multi_sample2d/moon.pkg
+++ b/examples/shaders/shaders_multi_sample2d/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/shaders/shaders_palette_switch/moon.pkg
+++ b/examples/shaders/shaders_palette_switch/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/shaders/shaders_postprocessing/moon.pkg
+++ b/examples/shaders/shaders_postprocessing/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/shaders/shaders_raymarching/moon.pkg
+++ b/examples/shaders/shaders_raymarching/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/shaders/shaders_rlgl_compute/moon.pkg
+++ b/examples/shaders/shaders_rlgl_compute/moon.pkg
@@ -6,3 +6,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/shaders/shaders_shadowmap/moon.pkg
+++ b/examples/shaders/shaders_shadowmap/moon.pkg
@@ -6,3 +6,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/shaders/shaders_shapes_textures/moon.pkg
+++ b/examples/shaders/shaders_shapes_textures/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/shaders/shaders_simple_mask/moon.pkg
+++ b/examples/shaders/shaders_simple_mask/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/shaders/shaders_spotlight/moon.pkg
+++ b/examples/shaders/shaders_spotlight/moon.pkg
@@ -6,3 +6,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/shaders/shaders_texture_drawing/moon.pkg
+++ b/examples/shaders/shaders_texture_drawing/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/shaders/shaders_texture_outline/moon.pkg
+++ b/examples/shaders/shaders_texture_outline/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/shaders/shaders_texture_tiling/moon.pkg
+++ b/examples/shaders/shaders_texture_tiling/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/shaders/shaders_texture_waves/moon.pkg
+++ b/examples/shaders/shaders_texture_waves/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/shaders/shaders_vertex_displacement/moon.pkg
+++ b/examples/shaders/shaders_vertex_displacement/moon.pkg
@@ -6,3 +6,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/shaders/shaders_write_depth/moon.pkg
+++ b/examples/shaders/shaders_write_depth/moon.pkg
@@ -6,3 +6,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/shapes/shapes_basic_shapes/moon.pkg
+++ b/examples/shapes/shapes_basic_shapes/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/shapes/shapes_bouncing_ball/moon.pkg
+++ b/examples/shapes/shapes_bouncing_ball/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/shapes/shapes_collision_area/moon.pkg
+++ b/examples/shapes/shapes_collision_area/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/shapes/shapes_colors_palette/moon.pkg
+++ b/examples/shapes/shapes_colors_palette/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/shapes/shapes_draw_circle_sector/moon.pkg
+++ b/examples/shapes/shapes_draw_circle_sector/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/shapes/shapes_draw_rectangle_rounded/moon.pkg
+++ b/examples/shapes/shapes_draw_rectangle_rounded/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/shapes/shapes_draw_ring/moon.pkg
+++ b/examples/shapes/shapes_draw_ring/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/shapes/shapes_easings_ball_anim/moon.pkg
+++ b/examples/shapes/shapes_easings_ball_anim/moon.pkg
@@ -6,3 +6,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/shapes/shapes_easings_box_anim/moon.pkg
+++ b/examples/shapes/shapes_easings_box_anim/moon.pkg
@@ -6,3 +6,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/shapes/shapes_easings_rectangle_array/moon.pkg
+++ b/examples/shapes/shapes_easings_rectangle_array/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/shapes/shapes_following_eyes/moon.pkg
+++ b/examples/shapes/shapes_following_eyes/moon.pkg
@@ -6,3 +6,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/shapes/shapes_lines_bezier/moon.pkg
+++ b/examples/shapes/shapes_lines_bezier/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/shapes/shapes_logo_raylib/moon.pkg
+++ b/examples/shapes/shapes_logo_raylib/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/shapes/shapes_logo_raylib_anim/moon.pkg
+++ b/examples/shapes/shapes_logo_raylib_anim/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/shapes/shapes_rectangle_advanced/moon.pkg
+++ b/examples/shapes/shapes_rectangle_advanced/moon.pkg
@@ -7,3 +7,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/shapes/shapes_rectangle_scaling/moon.pkg
+++ b/examples/shapes/shapes_rectangle_scaling/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/shapes/shapes_splines_drawing/moon.pkg
+++ b/examples/shapes/shapes_splines_drawing/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/shapes/shapes_top_down_lights/moon.pkg
+++ b/examples/shapes/shapes_top_down_lights/moon.pkg
@@ -6,3 +6,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/text/text_codepoints_loading/moon.pkg
+++ b/examples/text/text_codepoints_loading/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/text/text_draw_3d/moon.pkg
+++ b/examples/text/text_draw_3d/moon.pkg
@@ -7,3 +7,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/text/text_font_filters/moon.pkg
+++ b/examples/text/text_font_filters/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/text/text_font_loading/moon.pkg
+++ b/examples/text/text_font_loading/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/text/text_font_sdf/moon.pkg
+++ b/examples/text/text_font_sdf/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/text/text_font_spritefont/moon.pkg
+++ b/examples/text/text_font_spritefont/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/text/text_format_text/moon.pkg
+++ b/examples/text/text_format_text/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/text/text_input_box/moon.pkg
+++ b/examples/text/text_input_box/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/text/text_raylib_fonts/moon.pkg
+++ b/examples/text/text_raylib_fonts/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/text/text_rectangle_bounds/moon.pkg
+++ b/examples/text/text_rectangle_bounds/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/text/text_unicode/moon.pkg
+++ b/examples/text/text_unicode/moon.pkg
@@ -6,3 +6,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/text/text_writing_anim/moon.pkg
+++ b/examples/text/text_writing_anim/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/textures/textures_background_scrolling/moon.pkg
+++ b/examples/textures/textures_background_scrolling/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/textures/textures_blend_modes/moon.pkg
+++ b/examples/textures/textures_blend_modes/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/textures/textures_bunnymark/moon.pkg
+++ b/examples/textures/textures_bunnymark/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/textures/textures_draw_tiled/moon.pkg
+++ b/examples/textures/textures_draw_tiled/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/textures/textures_fog_of_war/moon.pkg
+++ b/examples/textures/textures_fog_of_war/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/textures/textures_gif_player/moon.pkg
+++ b/examples/textures/textures_gif_player/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/textures/textures_image_channel/moon.pkg
+++ b/examples/textures/textures_image_channel/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/textures/textures_image_drawing/moon.pkg
+++ b/examples/textures/textures_image_drawing/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/textures/textures_image_generation/moon.pkg
+++ b/examples/textures/textures_image_generation/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/textures/textures_image_kernel/moon.pkg
+++ b/examples/textures/textures_image_kernel/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/textures/textures_image_loading/moon.pkg
+++ b/examples/textures/textures_image_loading/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/textures/textures_image_processing/moon.pkg
+++ b/examples/textures/textures_image_processing/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/textures/textures_image_rotate/moon.pkg
+++ b/examples/textures/textures_image_rotate/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/textures/textures_image_text/moon.pkg
+++ b/examples/textures/textures_image_text/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/textures/textures_logo_raylib/moon.pkg
+++ b/examples/textures/textures_logo_raylib/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/textures/textures_mouse_painting/moon.pkg
+++ b/examples/textures/textures_mouse_painting/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/textures/textures_npatch_drawing/moon.pkg
+++ b/examples/textures/textures_npatch_drawing/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/textures/textures_particles_blending/moon.pkg
+++ b/examples/textures/textures_particles_blending/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/textures/textures_polygon/moon.pkg
+++ b/examples/textures/textures_polygon/moon.pkg
@@ -6,3 +6,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/textures/textures_raw_data/moon.pkg
+++ b/examples/textures/textures_raw_data/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/textures/textures_sprite_anim/moon.pkg
+++ b/examples/textures/textures_sprite_anim/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/textures/textures_sprite_button/moon.pkg
+++ b/examples/textures/textures_sprite_button/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/textures/textures_sprite_explosion/moon.pkg
+++ b/examples/textures/textures_sprite_explosion/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/textures/textures_srcrec_dstrec/moon.pkg
+++ b/examples/textures/textures_srcrec_dstrec/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/textures/textures_textured_curve/moon.pkg
+++ b/examples/textures/textures_textured_curve/moon.pkg
@@ -6,3 +6,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/examples/textures/textures_to_image/moon.pkg
+++ b/examples/textures/textures_to_image/moon.pkg
@@ -5,3 +5,5 @@ import {
 options(
   "is-main": true,
 )
+
+supported_targets = "native"

--- a/internal/raylib/moon.pkg
+++ b/internal/raylib/moon.pkg
@@ -1,3 +1,5 @@
+supported_targets = "native"
+
 options(
   link: { "native": { "stub-cc-flags": "${build.RAYLIB_STUB_CC_FLAGS}" } },
   "native-stub": [
@@ -25,5 +27,3 @@ options(
     "stub_rlgl.c",
   ],
 )
-
-supported_targets = "native"

--- a/internal/raylib/moon.pkg
+++ b/internal/raylib/moon.pkg
@@ -25,3 +25,5 @@ options(
     "stub_rlgl.c",
   ],
 )
+
+supported_targets = "native"

--- a/moon.pkg
+++ b/moon.pkg
@@ -7,3 +7,5 @@ import {
 }
 
 warnings = "+test_unqualified_package"
+
+supported_targets = "native"

--- a/raygui/moon.pkg
+++ b/raygui/moon.pkg
@@ -2,3 +2,5 @@ import {
   "moonbitlang/core/debug",
   "tonyfettes/raylib",
 }
+
+supported_targets = "native"

--- a/rl/moon.pkg
+++ b/rl/moon.pkg
@@ -3,3 +3,5 @@ import {
   "tonyfettes/raylib/internal/raylib",
   "moonbitlang/core/encoding/utf8",
 }
+
+supported_targets = "native"


### PR DESCRIPTION
## Summary

Marks all tracked `moon.pkg` packages in this repository with `supported_targets = "native"`.

This keeps the raylib binding, raygui package, internal C stub package, and examples explicitly native-only so downstream workspaces do not try to resolve/build them for non-native targets.

This PR is intentionally separate from the raylib 6.0 upgrade PR.

## Validation

- `moon check --target native`
- `moon test --target native`
- `moon fmt`
- `moon info`